### PR TITLE
Fix for getting the correct version from workflow controller

### DIFF
--- a/actions/deis.js
+++ b/actions/deis.js
@@ -119,7 +119,7 @@ export const controllerInfo = () => (
   client.options('/', {}, {
     action: { type: 'CONTROLLER_INFO' },
     mapResponse: (response, json, baseAction) => {
-      const version = response.headers.get('X_DEIS_API_VERSION')
+      const version = response.headers.get('X_DEIS_API_VERSION') ? response.headers.get('X_DEIS_API_VERSION') : response.headers.get('DEIS_API_VERSION')
       if (version) {
         return {
           ...baseAction,


### PR DESCRIPTION
Looks like the api version header has changed from X_DEIS_API_VERSION to DEIS_API_VERSION. Just updated to use whichever one is available. This seems to at lease mostly enable support for the workflow release, as the API hasn't changed much.
